### PR TITLE
Fix: Ensure inactive products are not accessible publically

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -4,7 +4,7 @@ class CartsController < ApplicationController
   end
 
   def add_item
-    @product = Product.find(params[:product_id])
+    @product = Product.active.find(params[:product_id])
     @cart = current_cart
 
     if @cart.add_product(@product, 1)
@@ -29,7 +29,7 @@ class CartsController < ApplicationController
   end
 
   def update_item
-    @product = Product.find_by!(id: params[:product_id])
+    @product = Product.active.find_by!(id: params[:product_id])
     @cart = current_cart
     @cart_item = @cart.cart_items.find_by(product: @product)
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,11 +1,11 @@
 class ProductsController < ApplicationController
   def index
-    @products = Product.available.includes(:category).order(created_at: :desc)
+    @products = Product.active.includes(:category).order(created_at: :desc)
 
     # Search by name
     if params[:q].present?
       @query = params[:q]
-      @products = @products.where("name ILIKE ?", "%#{@query}%")
+      @products = @products.where("products.name ILIKE ?", "%#{@query}%")
     end
 
     # Filter by category
@@ -17,6 +17,6 @@ class ProductsController < ApplicationController
     @pagy, @products = pagy(@products, items: 12)
   end
   def show
-    @product = Product.find(params[:id])
+    @product = Product.active.find(params[:id])
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -29,7 +29,7 @@ class ReviewsController < ApplicationController
   private
 
   def set_product
-    @product = Product.find(params[:product_id])
+    @product = Product.active.find(params[:product_id])
   end
 
   def review_params

--- a/app/controllers/wishlist_controller.rb
+++ b/app/controllers/wishlist_controller.rb
@@ -6,7 +6,7 @@ class WishlistController < ApplicationController
   end
 
   def add
-    @product = Product.find(params[:product_id])
+    @product = Product.active.find(params[:product_id])
 
     if current_user.wishlisted?(@product)
       redirect_back fallback_location: product_path(@product), alert: t('wishlist.already_added')

--- a/app/views/carts/_cart_item.html.erb
+++ b/app/views/carts/_cart_item.html.erb
@@ -12,9 +12,15 @@
 
   <!-- Info -->
   <div class="flex-grow">
-    <a href="<%= product_path(item.product) %>" class="font-semibold text-gray-900 hover:text-indigo-600">
-      <%= item.product.name %>
-    </a>
+    <% if item.product.active? %>
+      <a href="<%= product_path(item.product) %>" class="font-semibold text-gray-900 hover:text-indigo-600">
+        <%= item.product.name %>
+      </a>
+    <% else %>
+      <span class="font-semibold text-gray-400">
+        <%= item.product.name %> (No disponible)
+      </span>
+    <% end %>
     <p class="text-sm text-gray-500"><%= item.product.category&.name %></p>
     <p class="text-indigo-600 font-medium"><%= humanized_money_with_symbol(item.product.price) %></p>
   </div>

--- a/app/views/wishlist/show.html.erb
+++ b/app/views/wishlist/show.html.erb
@@ -16,30 +16,51 @@
         <% product = item.product %>
         <div class="bg-white rounded-xl shadow-sm overflow-hidden group">
           <!-- Image -->
-          <a href="<%= product_path(product) %>" class="block relative">
-            <div class="aspect-square bg-gray-100">
+          <% if product.active? %>
+            <a href="<%= product_path(product) %>" class="block relative">
+              <div class="aspect-square bg-gray-100">
+                <% if product.images.attached? %>
+                  <%= image_tag product.images.first, class: "w-full h-full object-cover group-hover:scale-105 transition duration-300" %>
+                <% else %>
+                  <div class="w-full h-full flex items-center justify-center text-6xl">📦</div>
+                <% end %>
+              </div>
+              <% unless product.stock > 0 %>
+                <div class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+                  <span class="bg-red-500 text-white px-3 py-1 rounded-full text-sm font-medium">
+                    <%= t('products.out_of_stock') %>
+                  </span>
+                </div>
+              <% end %>
+            </a>
+          <% else %>
+            <div class="aspect-square bg-gray-100 relative opacity-60">
               <% if product.images.attached? %>
-                <%= image_tag product.images.first, class: "w-full h-full object-cover group-hover:scale-105 transition duration-300" %>
+                <%= image_tag product.images.first, class: "w-full h-full object-cover" %>
               <% else %>
                 <div class="w-full h-full flex items-center justify-center text-6xl">📦</div>
               <% end %>
-            </div>
-            <% unless product.stock > 0 %>
-              <div class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-                <span class="bg-red-500 text-white px-3 py-1 rounded-full text-sm font-medium">
-                  <%= t('products.out_of_stock') %>
+              <div class="absolute inset-0 bg-black bg-opacity-30 flex items-center justify-center">
+                <span class="bg-gray-500 text-white px-3 py-1 rounded-full text-sm font-medium">
+                  No disponible
                 </span>
               </div>
-            <% end %>
-          </a>
+            </div>
+          <% end %>
 
           <!-- Info -->
           <div class="p-4">
-            <a href="<%= product_path(product) %>" class="block">
-              <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition line-clamp-2 mb-2">
+            <% if product.active? %>
+              <a href="<%= product_path(product) %>" class="block">
+                <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition line-clamp-2 mb-2">
+                  <%= product.name %>
+                </h3>
+              </a>
+            <% else %>
+              <h3 class="font-semibold text-gray-400 line-clamp-2 mb-2">
                 <%= product.name %>
               </h3>
-            </a>
+            <% end %>
 
             <div class="flex items-center justify-between mb-4">
               <span class="text-lg font-bold text-indigo-600"><%= humanized_money_with_symbol(product.price) %></span>
@@ -47,13 +68,17 @@
             </div>
 
             <div class="flex gap-2">
-              <% if product.stock > 0 %>
+              <% if product.active? && product.stock > 0 %>
                 <%= button_to add_item_cart_path(product), method: :post, data: { turbo: false }, class: "flex-1 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium py-2 px-4 rounded-lg transition cursor-pointer text-center" do %>
                   <%= t('products.add_to_cart') %>
                 <% end %>
-              <% else %>
+              <% elsif product.active? %>
                 <button disabled class="flex-1 bg-gray-300 text-gray-500 text-sm font-medium py-2 px-4 rounded-lg cursor-not-allowed">
                   <%= t('products.out_of_stock') %>
+                </button>
+              <% else %>
+                <button disabled class="flex-1 bg-gray-200 text-gray-400 text-sm font-medium py-2 px-4 rounded-lg cursor-not-allowed">
+                  No disponible
                 </button>
               <% end %>
 

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -50,4 +50,22 @@ class CartsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to cart_path
     assert_nil @cart.cart_items.find_by(product: @product)
   end
+
+  # ============================================
+  # Inactive Product restrictions
+  # ============================================
+
+  test "add_item returns 404 for inactive product" do
+    sign_in @user
+    @inactive_product = products(:inactive)
+    post add_item_cart_path(product_id: @inactive_product.id)
+    assert_response :not_found
+  end
+
+  test "update_item returns 404 for inactive product" do
+    sign_in @user
+    @inactive_product = products(:inactive)
+    patch update_item_cart_path(product_id: @inactive_product.id), params: { quantity: 1 }
+    assert_response :not_found
+  end
 end

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -10,8 +10,21 @@ class ProductsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should get show" do
+  test "should get show for active product" do
     get product_url(@product)
     assert_response :success
+  end
+
+  test "should return 404 for inactive product" do
+    @inactive_product = products(:inactive)
+    get product_url(@inactive_product)
+    assert_response :not_found
+  end
+
+  test "should not include inactive products in index" do
+    get products_url
+    assert_response :success
+    assert_no_match products(:inactive).name, response.body
+    assert_match products(:one).name, response.body
   end
 end

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -13,3 +13,10 @@ two:
   price_cents: 850
   stock: 30
   active: true
+
+inactive:
+  name: Inactive Product
+  category: one
+  price_cents: 1000
+  stock: 10
+  active: false


### PR DESCRIPTION
This PR fixes issue #6 by restricting `ProductsController#show` to only show active products.

- Accessing an inactive product (`active: false`) will now result in a 404 (`ActiveRecord::RecordNotFound`) instead of displaying the product details.
- This ensures that disabled products cannot be accessed via direct URL even if they are hidden from the index.