### PR TITLE
Require product category to match DB constraint

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,5 @@
 class Product < ApplicationRecord
-  belongs_to :category, optional: true
+  belongs_to :category
   has_rich_text :description
   has_many_attached :images
   has_many :cart_items, dependent: :destroy

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,7 +1,15 @@
 require "test_helper"
 
 class ProductTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "requires category" do
+    product = Product.new(
+      name: "Test Product",
+      price_cents: 1000,
+      stock: 5,
+      active: true
+    )
+
+    assert_not product.valid?
+    assert product.errors[:category].any?
+  end
 end


### PR DESCRIPTION
## Summary
- Remove optional category association so model validation matches DB constraint.
- Add model test to ensure category is required.

## Testing
- bundle exec rails test test/models/product_test.rb

Closes #7
