### PR TITLE
Disable unused coupon discount input

### DIFF
--- a/app/javascript/controllers/coupon_form_controller.js
+++ b/app/javascript/controllers/coupon_form_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="coupon-form"
+export default class extends Controller {
+  static targets = ["discountType", "percentage", "amount"]
+
+  connect() {
+    this.sync()
+  }
+
+  sync() {
+    if (!this.hasDiscountTypeTarget) return
+
+    const type = this.discountTypeTarget.value
+    const isPercentage = type === "percentage"
+
+    if (this.hasPercentageTarget) {
+      this.percentageTarget.disabled = !isPercentage
+      if (!isPercentage) this.percentageTarget.value = ""
+    }
+
+    if (this.hasAmountTarget) {
+      this.amountTarget.disabled = isPercentage
+      if (isPercentage) this.amountTarget.value = ""
+    }
+  }
+}

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -12,6 +12,7 @@ class Coupon < ApplicationRecord
   validates :discount_amount_cents, numericality: { greater_than: 0 }, if: :fixed_amount?
 
   before_validation :normalize_code
+  before_validation :clear_unused_discount_value
 
   scope :active, -> { where(active: true) }
   scope :valid_now, -> {
@@ -53,6 +54,14 @@ class Coupon < ApplicationRecord
 
   def normalize_code
     self.code = code.to_s.upcase.strip
+  end
+
+  def clear_unused_discount_value
+    if percentage?
+      self.discount_amount_cents = nil
+    elsif fixed_amount?
+      self.discount_percentage = nil
+    end
   end
 
   def expired?

--- a/app/views/admin/coupons/_form.html.erb
+++ b/app/views/admin/coupons/_form.html.erb
@@ -1,16 +1,25 @@
-<div class="bg-white rounded-lg shadow p-6">
+<div class="bg-white rounded-lg shadow p-6" data-controller="coupon-form">
   <%= simple_form_for [:admin, @coupon], html: { class: "space-y-6" } do |f| %>
     <%= f.error_notification %>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <%= f.input :code, label: "Código", hint: "Ej: VERANO20, BIENVENIDO10", input_html: { class: "uppercase" } %>
 
-      <%= f.input :discount_type, collection: [["Porcentaje (%)", :percentage], ["Monto fijo ($)", :fixed_amount]], label: "Tipo de descuento" %>
+      <%= f.input :discount_type,
+        collection: [["Porcentaje (%)", :percentage], ["Monto fijo ($)", :fixed_amount]],
+        label: "Tipo de descuento",
+        input_html: { data: { coupon_form_target: "discountType", action: "change->coupon-form#sync" } } %>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <%= f.input :discount_percentage, label: "Porcentaje de descuento", hint: "Ej: 10 para 10%", input_html: { min: 1, max: 100 } %>
-      <%= f.input :discount_amount, label: "Monto de descuento (USD)", hint: "Ej: 5.00 para $5 de descuento" %>
+      <%= f.input :discount_percentage,
+        label: "Porcentaje de descuento",
+        hint: "Ej: 10 para 10%",
+        input_html: { min: 1, max: 100, data: { coupon_form_target: "percentage" } } %>
+      <%= f.input :discount_amount,
+        label: "Monto de descuento (USD)",
+        hint: "Ej: 5.00 para $5 de descuento",
+        input_html: { data: { coupon_form_target: "amount" } } %>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/test/models/coupon_test.rb
+++ b/test/models/coupon_test.rb
@@ -1,7 +1,34 @@
 require "test_helper"
 
 class CouponTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "clears fixed amount when percentage coupon" do
+    coupon = Coupon.new(
+      code: "PERCENT10",
+      discount_type: :percentage,
+      discount_percentage: 10,
+      discount_amount_cents: 500
+    )
+
+    assert coupon.valid?
+    assert_nil coupon.discount_amount_cents
+  end
+
+  test "clears percentage when fixed amount coupon" do
+    coupon = Coupon.new(
+      code: "FIXED5",
+      discount_type: :fixed_amount,
+      discount_amount_cents: 500,
+      discount_percentage: 10
+    )
+
+    assert coupon.valid?
+    assert_nil coupon.discount_percentage
+  end
+
+  test "requires percentage value for percentage coupons" do
+    coupon = Coupon.new(code: "PCT", discount_type: :percentage)
+
+    assert_not coupon.valid?
+    assert coupon.errors[:discount_percentage].any?
+  end
 end


### PR DESCRIPTION
## Summary
- Disable and clear the non-selected discount input (percentage vs fixed amount) in the admin coupon form.
- Normalize coupon model values to clear unused fields.
- Add model tests for discount-type behavior.

## Testing
- bundle exec rails test test/models/coupon_test.rb

Closes #27
