### PR TITLE
fix: avoid early AR encryption config read

### DIFF
--- a/app/views/admin/two_factor/show.html.erb
+++ b/app/views/admin/two_factor/show.html.erb
@@ -44,7 +44,7 @@
       <p class="text-sm text-gray-600 mb-4"><%= t("admin.two_factor.backup_codes_hint") %></p>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <% current_user.otp_backup_codes.each do |code| %>
-          <div class="bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 font-mono text-sm text-gray-800">
+          <div class="bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 font-mono text-sm text-gray-800 break-all">
             <%= code %>
           </div>
         <% end %>

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -3,10 +3,9 @@
 # Ensure Active Record Encryption keys are present in development/test to avoid
 # boot/runtime errors when encrypted attributes are used (e.g., OTP secrets).
 app_encryption = Rails.application.config.active_record.encryption
-encryption = ActiveRecord::Encryption.config
-primary_key = encryption.primary_key.presence || app_encryption.primary_key
-deterministic_key = encryption.deterministic_key.presence || app_encryption.deterministic_key
-key_derivation_salt = encryption.key_derivation_salt.presence || app_encryption.key_derivation_salt
+primary_key = app_encryption.primary_key
+deterministic_key = app_encryption.deterministic_key
+key_derivation_salt = app_encryption.key_derivation_salt
 
 if primary_key.blank? || deterministic_key.blank? || key_derivation_salt.blank?
   if Rails.env.development? || Rails.env.test?
@@ -16,10 +15,6 @@ if primary_key.blank? || deterministic_key.blank? || key_derivation_salt.blank?
     primary_key ||= generator.generate_key("active_record_encryption_primary_key", 32)
     deterministic_key ||= generator.generate_key("active_record_encryption_deterministic_key", 32)
     key_derivation_salt ||= generator.generate_key("active_record_encryption_key_derivation_salt", 32)
-
-    encryption.primary_key = primary_key
-    encryption.deterministic_key = deterministic_key
-    encryption.key_derivation_salt = key_derivation_salt
 
     app_encryption.primary_key = primary_key
     app_encryption.deterministic_key = deterministic_key

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -3,9 +3,9 @@
 # Ensure Active Record Encryption keys are present in development/test to avoid
 # boot/runtime errors when encrypted attributes are used (e.g., OTP secrets).
 app_encryption = Rails.application.config.active_record.encryption
-primary_key = app_encryption.primary_key
-deterministic_key = app_encryption.deterministic_key
-key_derivation_salt = app_encryption.key_derivation_salt
+primary_key = app_encryption.primary_key.presence
+deterministic_key = app_encryption.deterministic_key.presence
+key_derivation_salt = app_encryption.key_derivation_salt.presence
 
 if primary_key.blank? || deterministic_key.blank? || key_derivation_salt.blank?
   if Rails.env.development? || Rails.env.test?


### PR DESCRIPTION
## Summary
- Avoid touching ActiveRecord::Encryption.config before keys are set.
- Initialize keys only via app config in dev/test; keep production strict.

## Testing
- Not run (local).